### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-18.04]
-        ruby: [2.5, 2.6, 2.7, 3.0]
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Also quoted 3.0 to prevent truncation to 3.  This ensures that a 3.0.x Ruby version is run in CI.